### PR TITLE
Validation (based on deepmap/oapi-codegen#365)

### DIFF
--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -154,7 +154,6 @@ func (s AdditionalPropertiesObject5) Validate() error {
 			AdditionalProperties map[string]SchemaObject `json:"-"`
 		})(s),
 	)
-
 }
 
 // ObjectWithJsonField defines model for ObjectWithJsonField.

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -32,7 +32,6 @@ func (s ArrayValue) Validate() error {
 		([]Value)(s),
 		validation.Each(),
 	)
-
 }
 
 // Document defines model for Document.
@@ -65,7 +64,6 @@ func (s Document_Fields) Validate() error {
 			AdditionalProperties map[string]Value `json:"-"`
 		})(s),
 	)
-
 }
 
 // Value defines model for Value.

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -59,7 +59,6 @@ func (s Bar) Validate() error {
 	return validation.Validate(
 		(string)(s),
 	)
-
 }
 
 // GetFooResponseOK defines parameters for GetFoo.

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -40,7 +40,6 @@ func (s N5StartsWithNumber) Validate() error {
 	return validation.Validate(
 		(map[string]interface{})(s),
 	)
-
 }
 
 // AnyType1 defines model for AnyType1.
@@ -52,7 +51,6 @@ func (s AnyType1) Validate() error {
 	return validation.Validate(
 		(interface{})(s),
 	)
-
 }
 
 // AnyType2 represents any type.
@@ -66,7 +64,6 @@ func (s AnyType2) Validate() error {
 	return validation.Validate(
 		(interface{})(s),
 	)
-
 }
 
 // CustomStringType defines model for CustomStringType.
@@ -78,7 +75,6 @@ func (s CustomStringType) Validate() error {
 	return validation.Validate(
 		(string)(s),
 	)
-
 }
 
 // GenericObject defines model for GenericObject.
@@ -90,7 +86,6 @@ func (s GenericObject) Validate() error {
 	return validation.Validate(
 		(map[string]interface{})(s),
 	)
-
 }
 
 // NullableProperties defines model for NullableProperties.
@@ -132,7 +127,6 @@ func (s StringInPath) Validate() error {
 	return validation.Validate(
 		(string)(s),
 	)
-
 }
 
 // EnsureEverythingIsReferencedResponseOK defines parameters for EnsureEverythingIsReferenced.

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -258,7 +258,6 @@ func (s Argument) Validate() error {
 	return validation.Validate(
 		(string)(s),
 	)
-
 }
 
 // ResponseWithReference defines model for ResponseWithReference.
@@ -270,7 +269,6 @@ func (s ResponseWithReference) Validate() error {
 	return validation.Validate(
 		(SomeObject)(s),
 	)
-
 }
 
 // SimpleResponse defines model for SimpleResponse.

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -197,7 +197,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 
 	outSchema := Schema{
 		Description: StringToGoComment(schema.Description),
-		OAPISchema: schema,
+		OAPISchema:  schema,
 	}
 	// Check for custom Go type extension
 	if extension, ok := schema.Extensions[extPropGoType]; ok {
@@ -215,11 +215,6 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 		outSchema.GoType = "interface{}"
 		return outSchema, nil
 	}
-	// We can't support this in any meaningful way
-	if schema.OneOf != nil {
-		outSchema.GoType = "interface{}"
-		return outSchema, nil
-	}
 
 	// AllOf is interesting, and useful. It's the union of a number of other
 	// schemas. A common usage is to create a union of an object with an ID,
@@ -232,16 +227,6 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 		}
 		mergedSchema.OAPISchema = schema
 		return mergedSchema, nil
-	}
-
-	// Check for custom Go type extension
-	if extension, ok := schema.Extensions[extPropGoType]; ok {
-		typeName, err := extTypeName(extension)
-		if err != nil {
-			return outSchema, errors.Wrapf(err, "invalid value for %q", extPropGoType)
-		}
-		outSchema.GoType = typeName
-		return outSchema, nil
 	}
 
 	// Schema type and format, eg. string / binary

--- a/pkg/codegen/templates/param-types.tmpl
+++ b/pkg/codegen/templates/param-types.tmpl
@@ -6,8 +6,7 @@ type {{.TypeName}} {{ if .CanAlias }}={{ end }} {{.Schema.TypeDecl}}
 {{ if not .Schema.RefType }}
 // Validate perform validation on the {{.TypeName}}
 func (s {{.TypeName}}) Validate() error {
-    {{- $v := .Schema.Validations -}}
-    {{ if eq (len .Schema.Properties) 0 }}
+    {{- if eq (len .Schema.Properties) 0 }}
     // Run validate on a scalar
     return validation.Validate(
         ({{.Schema.GoType}})(s),

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -1198,27 +1198,27 @@ func (s {{.TypeName}}) Validate() error {
 {{end}}
 
 {{ define "validateRules" }}
-{{- $s := .OAPISchema }}
-{{- if $s }}
-{{- if or $s.MinItems $s.MaxItems }}
-validation.Length({{if $s.MinItems}}{{$s.MinItems}}{{else}}0{{end}}, {{if $s.MaxItems}}{{ $s.MaxItems }}{{else}}0{{end}}),
+{{- $v := .OAPISchema }}
+{{- if $v }}
+{{- if or $v.MinItems $v.MaxItems }}
+validation.Length({{if $v.MinItems}}{{$v.MinItems}}{{else}}0{{end}}, {{if $v.MaxItems}}{{ $v.MaxItems }}{{else}}0{{end}}),
 {{ end }}
-{{- if or $s.MinProps $s.MaxProps }}
-validation.Length({{$s.MinProps}}, {{if $s.MaxProps}}{{ $s.MaxProps }}{{else}}0{{end}}),
+{{- if or $v.MinProps $v.MaxProps }}
+validation.Length({{$v.MinProps}}, {{if $v.MaxProps}}{{ $v.MaxProps }}{{else}}0{{end}}),
 {{ end }}
 {{- if .ItemType }}
 validation.Each(
     {{ template "validateRules" .ItemType }}
 ),
 {{ end }}
-{{- if $s.Min }} validation.Min({{ $s.Min }}){{if $s.ExclusiveMin}}.Exclusive(){{end}},{{end}}
-{{- if $s.Max }} validation.Max({{ $s.Max }}){{if $s.ExclusiveMax}}.Exclusive(){{end}},{{end}}
-{{- if $s.MultipleOf }} validation.MultipleOf({{ $s.MultipleOf }}),{{end}}
-{{- if or $s.MinLength $s.MaxLength }}
-validation.Length({{$s.MinLength}}, {{if $s.MaxLength}}{{ $s.MaxLength }}{{else}}0{{end}}),
+{{- if $v.Min }} validation.Min({{ $v.Min }}){{if $v.ExclusiveMin}}.Exclusive(){{end}},{{end}}
+{{- if $v.Max }} validation.Max({{ $v.Max }}){{if $v.ExclusiveMax}}.Exclusive(){{end}},{{end}}
+{{- if $v.MultipleOf }} validation.MultipleOf({{ $v.MultipleOf }}),{{end}}
+{{- if or $v.MinLength $v.MaxLength }}
+validation.Length({{$v.MinLength}}, {{if $v.MaxLength}}{{ $v.MaxLength }}{{else}}0{{end}}),
 {{- end }}
-{{- if ne $s.Pattern "" }}
-validation.Match(regexp.MustCompile({{ printf "%#v" $s.Pattern}})),
+{{- if ne $v.Pattern "" }}
+validation.Match(regexp.MustCompile({{ printf "%#v" $v.Pattern}})),
 {{- end }}
 {{- end }}
 {{ end }}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -863,8 +863,7 @@ type {{.TypeName}} {{ if .CanAlias }}={{ end }} {{.Schema.TypeDecl}}
 {{ if not .Schema.RefType }}
 // Validate perform validation on the {{.TypeName}}
 func (s {{.TypeName}}) Validate() error {
-    {{- $v := .Schema.Validations -}}
-    {{ if eq (len .Schema.Properties) 0 }}
+    {{- if eq (len .Schema.Properties) 0 }}
     // Run validate on a scalar
     return validation.Validate(
         ({{.Schema.GoType}})(s),

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -1159,14 +1159,13 @@ type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.Ty
 {{ if not .CanAlias }}
 // Validate perform validation on the {{.TypeName}}
 func (s {{.TypeName}}) Validate() error {
-    {{- $v := .Schema.Validations -}}
-    {{ if eq (len .Schema.Properties) 0 }}
-    {{- if ne (len $v.Values) 0 }}
+    {{- if eq (len .Schema.Properties) 0 }}
+    {{- if ne (len .Schema.EnumValues) 0 }}
     // Run validate on an enum
     if err := validation.Validate(
         s,
         validation.In(
-            {{ range $v.Values }}{{ printf "%v" . }},{{ end }}
+            {{ range $key, $value := .Schema.EnumValues }}{{ printf "%v" $key }},{{ end }}
         ),
         validation.Skip, // do not recurse infinitely
     ); err != nil {
@@ -1178,7 +1177,7 @@ func (s {{.TypeName}}) Validate() error {
         ({{.Schema.GoType}})(s),
         {{- template "validateRules" .Schema -}}
     )
-    {{ else }}
+    {{- else }}
     // Run validate on a struct
     return validation.ValidateStruct(
         &s,
@@ -1200,23 +1199,28 @@ func (s {{.TypeName}}) Validate() error {
 {{end}}
 
 {{ define "validateRules" }}
-{{- $v := .Validations }}
-{{- if or $v.MinItems $v.MaxItems }}
-validation.Length({{$v.MinItems}}, {{if $v.MaxItems}}{{ $v.MaxItems }}{{else}}0{{end}}),
+{{- $s := .OAPISchema }}
+{{- if $s }}
+{{- if or $s.MinItems $s.MaxItems }}
+validation.Length({{if $s.MinItems}}{{$s.MinItems}}{{else}}0{{end}}, {{if $s.MaxItems}}{{ $s.MaxItems }}{{else}}0{{end}}),
+{{ end }}
+{{- if or $s.MinProps $s.MaxProps }}
+validation.Length({{$s.MinProps}}, {{if $s.MaxProps}}{{ $s.MaxProps }}{{else}}0{{end}}),
 {{ end }}
 {{- if .ItemType }}
 validation.Each(
     {{ template "validateRules" .ItemType }}
 ),
 {{ end }}
-{{- if $v.Min }} validation.Min({{ $v.Min }}){{if $v.ExclusiveMin}}.Exclusive(){{end}},{{end}}
-{{- if $v.Max }} validation.Max({{ $v.Max }}){{if $v.ExclusiveMax}}.Exclusive(){{end}},{{end}}
-{{- if $v.MultipleOf }} validation.MultipleOf({{ $v.MultipleOf }}),{{end}}
-{{- if or $v.MinLength $v.MaxLength }}
-validation.Length({{$v.MinLength}}, {{if $v.MaxLength}}{{ $v.MaxLength }}{{else}}0{{end}}),
+{{- if $s.Min }} validation.Min({{ $s.Min }}){{if $s.ExclusiveMin}}.Exclusive(){{end}},{{end}}
+{{- if $s.Max }} validation.Max({{ $s.Max }}){{if $s.ExclusiveMax}}.Exclusive(){{end}},{{end}}
+{{- if $s.MultipleOf }} validation.MultipleOf({{ $s.MultipleOf }}),{{end}}
+{{- if or $s.MinLength $s.MaxLength }}
+validation.Length({{$s.MinLength}}, {{if $s.MaxLength}}{{ $s.MaxLength }}{{else}}0{{end}}),
 {{- end }}
-{{- if ne $v.Pattern "" }}
-validation.Match(regexp.MustCompile({{ printf "%#v" $v.Pattern}})),
+{{- if ne $s.Pattern "" }}
+validation.Match(regexp.MustCompile({{ printf "%#v" $s.Pattern}})),
+{{- end }}
 {{- end }}
 {{ end }}
 `,

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -5,14 +5,13 @@ type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.Ty
 {{ if not .CanAlias }}
 // Validate perform validation on the {{.TypeName}}
 func (s {{.TypeName}}) Validate() error {
-    {{- $v := .Schema.Validations -}}
-    {{ if eq (len .Schema.Properties) 0 }}
-    {{- if ne (len $v.Values) 0 }}
+    {{- if eq (len .Schema.Properties) 0 }}
+    {{- if ne (len .Schema.EnumValues) 0 }}
     // Run validate on an enum
     if err := validation.Validate(
         s,
         validation.In(
-            {{ range $v.Values }}{{ printf "%v" . }},{{ end }}
+            {{ range $key, $value := .Schema.EnumValues }}{{ printf "%v" $key }},{{ end }}
         ),
         validation.Skip, // do not recurse infinitely
     ); err != nil {
@@ -24,7 +23,7 @@ func (s {{.TypeName}}) Validate() error {
         ({{.Schema.GoType}})(s),
         {{- template "validateRules" .Schema -}}
     )
-    {{ else }}
+    {{- else }}
     // Run validate on a struct
     return validation.ValidateStruct(
         &s,
@@ -46,22 +45,27 @@ func (s {{.TypeName}}) Validate() error {
 {{end}}
 
 {{ define "validateRules" }}
-{{- $v := .Validations }}
-{{- if or $v.MinItems $v.MaxItems }}
-validation.Length({{$v.MinItems}}, {{if $v.MaxItems}}{{ $v.MaxItems }}{{else}}0{{end}}),
+{{- $s := .OAPISchema }}
+{{- if $s }}
+{{- if or $s.MinItems $s.MaxItems }}
+validation.Length({{if $s.MinItems}}{{$s.MinItems}}{{else}}0{{end}}, {{if $s.MaxItems}}{{ $s.MaxItems }}{{else}}0{{end}}),
+{{ end }}
+{{- if or $s.MinProps $s.MaxProps }}
+validation.Length({{$s.MinProps}}, {{if $s.MaxProps}}{{ $s.MaxProps }}{{else}}0{{end}}),
 {{ end }}
 {{- if .ItemType }}
 validation.Each(
     {{ template "validateRules" .ItemType }}
 ),
 {{ end }}
-{{- if $v.Min }} validation.Min({{ $v.Min }}){{if $v.ExclusiveMin}}.Exclusive(){{end}},{{end}}
-{{- if $v.Max }} validation.Max({{ $v.Max }}){{if $v.ExclusiveMax}}.Exclusive(){{end}},{{end}}
-{{- if $v.MultipleOf }} validation.MultipleOf({{ $v.MultipleOf }}),{{end}}
-{{- if or $v.MinLength $v.MaxLength }}
-validation.Length({{$v.MinLength}}, {{if $v.MaxLength}}{{ $v.MaxLength }}{{else}}0{{end}}),
+{{- if $s.Min }} validation.Min({{ $s.Min }}){{if $s.ExclusiveMin}}.Exclusive(){{end}},{{end}}
+{{- if $s.Max }} validation.Max({{ $s.Max }}){{if $s.ExclusiveMax}}.Exclusive(){{end}},{{end}}
+{{- if $s.MultipleOf }} validation.MultipleOf({{ $s.MultipleOf }}),{{end}}
+{{- if or $s.MinLength $s.MaxLength }}
+validation.Length({{$s.MinLength}}, {{if $s.MaxLength}}{{ $s.MaxLength }}{{else}}0{{end}}),
 {{- end }}
-{{- if ne $v.Pattern "" }}
-validation.Match(regexp.MustCompile({{ printf "%#v" $v.Pattern}})),
+{{- if ne $s.Pattern "" }}
+validation.Match(regexp.MustCompile({{ printf "%#v" $s.Pattern}})),
+{{- end }}
 {{- end }}
 {{ end }}

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -45,27 +45,27 @@ func (s {{.TypeName}}) Validate() error {
 {{end}}
 
 {{ define "validateRules" }}
-{{- $s := .OAPISchema }}
-{{- if $s }}
-{{- if or $s.MinItems $s.MaxItems }}
-validation.Length({{if $s.MinItems}}{{$s.MinItems}}{{else}}0{{end}}, {{if $s.MaxItems}}{{ $s.MaxItems }}{{else}}0{{end}}),
+{{- $v := .OAPISchema }}
+{{- if $v }}
+{{- if or $v.MinItems $v.MaxItems }}
+validation.Length({{if $v.MinItems}}{{$v.MinItems}}{{else}}0{{end}}, {{if $v.MaxItems}}{{ $v.MaxItems }}{{else}}0{{end}}),
 {{ end }}
-{{- if or $s.MinProps $s.MaxProps }}
-validation.Length({{$s.MinProps}}, {{if $s.MaxProps}}{{ $s.MaxProps }}{{else}}0{{end}}),
+{{- if or $v.MinProps $v.MaxProps }}
+validation.Length({{$v.MinProps}}, {{if $v.MaxProps}}{{ $v.MaxProps }}{{else}}0{{end}}),
 {{ end }}
 {{- if .ItemType }}
 validation.Each(
     {{ template "validateRules" .ItemType }}
 ),
 {{ end }}
-{{- if $s.Min }} validation.Min({{ $s.Min }}){{if $s.ExclusiveMin}}.Exclusive(){{end}},{{end}}
-{{- if $s.Max }} validation.Max({{ $s.Max }}){{if $s.ExclusiveMax}}.Exclusive(){{end}},{{end}}
-{{- if $s.MultipleOf }} validation.MultipleOf({{ $s.MultipleOf }}),{{end}}
-{{- if or $s.MinLength $s.MaxLength }}
-validation.Length({{$s.MinLength}}, {{if $s.MaxLength}}{{ $s.MaxLength }}{{else}}0{{end}}),
+{{- if $v.Min }} validation.Min({{ $v.Min }}){{if $v.ExclusiveMin}}.Exclusive(){{end}},{{end}}
+{{- if $v.Max }} validation.Max({{ $v.Max }}){{if $v.ExclusiveMax}}.Exclusive(){{end}},{{end}}
+{{- if $v.MultipleOf }} validation.MultipleOf({{ $v.MultipleOf }}),{{end}}
+{{- if or $v.MinLength $v.MaxLength }}
+validation.Length({{$v.MinLength}}, {{if $v.MaxLength}}{{ $v.MaxLength }}{{else}}0{{end}}),
 {{- end }}
-{{- if ne $s.Pattern "" }}
-validation.Match(regexp.MustCompile({{ printf "%#v" $s.Pattern}})),
+{{- if ne $v.Pattern "" }}
+validation.Match(regexp.MustCompile({{ printf "%#v" $v.Pattern}})),
 {{- end }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
- Clean up deepmap/oapi-codegen#225.
- Now use deepmap/oapi-codegen#365's exposed `openapi3.Schema` to generate validation code.