### PR TITLE
Add support for no-content 204 responses

### DIFF
--- a/examples/petstore-expanded/echo/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-server.gen.go
@@ -74,6 +74,11 @@ type DeletePetContext struct {
 
 // Responses
 
+// NoContent returns the successful response with no body.
+func (c *DeletePetContext) NoContent() error {
+	return c.NoContent(204)
+}
+
 // FindPetByIDContext is a context customized for FindPetByID (GET /pets/{id}).
 type FindPetByIDContext struct {
 	echo.Context

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -245,11 +245,10 @@ func (o *OperationDefinition) HasBody() bool {
 	return o.Spec.RequestBody != nil
 }
 
-// HasEmptySuccess returns whether the operation has an empty
-// success response.
-func (o *OperationDefinition) HasEmptySuccess() bool {
-	successResp := o.Spec.Responses.Get(200)
-	return successResp != nil && len(successResp.Value.Content) == 0
+// HasNoContent returns whether the operation has a no-content response on the given code.
+func (o *OperationDefinition) HasNoContent(status int) bool {
+	resp := o.Spec.Responses.Get(status)
+	return resp != nil && len(resp.Value.Content) == 0
 }
 
 // This returns the Operations summary as a multi line comment

--- a/pkg/codegen/templates/server-interface.tmpl
+++ b/pkg/codegen/templates/server-interface.tmpl
@@ -27,10 +27,16 @@ func (c *{{$op.OperationId}}Context) Parse{{.NameTag}}Body() ({{$op.OperationId}
 {{- if gt (len .GetResponseTypeDefinitions) 0 }}
 
 // Responses
-{{ if $op.HasEmptySuccess }}
+{{ if $op.HasNoContent 200 }}
 // OK returns the successful response with no body.
 func (c *{{$op.OperationId}}Context) OK() error {
     return c.NoContent(200)
+}
+{{- end }}
+{{ if $op.HasNoContent 204 }}
+// NoContent returns the successful response with no body.
+func (c *{{$op.OperationId}}Context) NoContent() error {
+    return c.NoContent(204)
 }
 {{- end }}
 {{- range .GetResponseIndependentTypeDefinitions }}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -965,10 +965,16 @@ func (c *{{$op.OperationId}}Context) Parse{{.NameTag}}Body() ({{$op.OperationId}
 {{- if gt (len .GetResponseTypeDefinitions) 0 }}
 
 // Responses
-{{ if $op.HasEmptySuccess }}
+{{ if $op.HasNoContent 200 }}
 // OK returns the successful response with no body.
 func (c *{{$op.OperationId}}Context) OK() error {
     return c.NoContent(200)
+}
+{{- end }}
+{{ if $op.HasNoContent 204 }}
+// NoContent returns the successful response with no body.
+func (c *{{$op.OperationId}}Context) NoContent() error {
+    return c.NoContent(204)
 }
 {{- end }}
 {{- range .GetResponseIndependentTypeDefinitions }}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -1093,10 +1093,17 @@ type {{$opid}}TestResponse struct {
     tc *TestClient
 }
 
-{{ if $op.HasEmptySuccess }}
+{{ if $op.HasNoContent 200 }}
 // OK asserts a successful response with no body.
 func (c *{{$op.OperationId}}TestResponse) OK() {
     require.Equalf(c.tb, 200, c.StatusCode, "expected status code 200, got %d", c.StatusCode)
+    require.Equalf(c.tb, int64(0), c.ContentLength, "expected zero content length, got %d", c.ContentLength)
+}
+{{- end }}
+{{ if $op.HasNoContent 204 }}
+// OK asserts a successful response with no body.
+func (c *{{$op.OperationId}}TestResponse) OK() {
+    require.Equalf(c.tb, 204, c.StatusCode, "expected status code 204, got %d", c.StatusCode)
     require.Equalf(c.tb, int64(0), c.ContentLength, "expected zero content length, got %d", c.ContentLength)
 }
 {{- end }}

--- a/pkg/codegen/templates/test-client.tmpl
+++ b/pkg/codegen/templates/test-client.tmpl
@@ -48,10 +48,17 @@ type {{$opid}}TestResponse struct {
     tc *TestClient
 }
 
-{{ if $op.HasEmptySuccess }}
+{{ if $op.HasNoContent 200 }}
 // OK asserts a successful response with no body.
 func (c *{{$op.OperationId}}TestResponse) OK() {
     require.Equalf(c.tb, 200, c.StatusCode, "expected status code 200, got %d", c.StatusCode)
+    require.Equalf(c.tb, int64(0), c.ContentLength, "expected zero content length, got %d", c.ContentLength)
+}
+{{- end }}
+{{ if $op.HasNoContent 204 }}
+// OK asserts a successful response with no body.
+func (c *{{$op.OperationId}}TestResponse) OK() {
+    require.Equalf(c.tb, 204, c.StatusCode, "expected status code 204, got %d", c.StatusCode)
     require.Equalf(c.tb, int64(0), c.ContentLength, "expected zero content length, got %d", c.ContentLength)
 }
 {{- end }}


### PR DESCRIPTION
- `HasEmptySuccess` is now `HasNoContent`, and is parameterized by the status code. We can re-use this for 
both existing 200 responses and the correct 204 (No Content) response.
- Template handles this case by calling `HasNoContent` on both.

