### PR TITLE
Update to upstream's v1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,9 +430,32 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
 `oapi-codegen` supports the following extended properties:
 
 - `x-go-type`: specifies Go type name. It allows you to specify the type name for a schema, and
- will override any default value. This extended property isn't supported in all parts of
- OpenAPI, so please refer to the spec as to where it's allowed. Swagger validation tools will
- flag incorrect usage of this property.
+  will override any default value. This extended property isn't supported in all parts of
+  OpenAPI, so please refer to the spec as to where it's allowed. Swagger validation tools will
+  flag incorrect usage of this property.
+- `x-oapi-codegen-extra-tags`: adds extra Go field tags to the generated struct field. This is
+  useful for interfacing with tag based ORM or validation libraries. The extra tags that
+  are added are in addition to the regular json tags that are generated. If you specify your 
+  own `json` tag, you will override the default one. 
+
+    ```yaml
+    components:
+      schemas:
+        Object:
+          properties:
+            name:
+              type: string
+              x-oapi-codegen-extra-tags:
+                tag1: value1
+                tag2: value2
+    ```
+  In the example above, field `name` will be declared as: 
+  
+  ```
+  Name string `json:"name" tag1:"value1" tag2:"value2"`
+  ```
+  
+
 
 ## Using `oapi-codegen`
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/go-ozzo/ozzo-validation/v4 v4.2.1 h1:XALUNshPYumA7UShB7iM3ZVlqIBn0jfw
 github.com/go-ozzo/ozzo-validation/v4 v4.2.1/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219 h1:utua3L2IbQJmauC5IXdEA547bcoU5dozgQAfc8Onsg4=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -27,17 +27,19 @@ const (
 
 	BarFoo Bar = "Foo"
 
-	BarFoo1 Bar = "1Foo"
+	BarFoo1 Bar = " Foo"
 
-	BarFoo2 Bar = " Foo"
+	BarFoo2 Bar = " Foo "
 
-	BarFoo3 Bar = " Foo "
-
-	BarFoo4 Bar = "_Foo_"
+	BarFoo3 Bar = "_Foo_"
 
 	BarFooBar Bar = "Foo Bar"
 
 	BarFooBar1 Bar = "Foo-Bar"
+
+	BarN1 Bar = "1"
+
+	BarN1Foo Bar = "1Foo"
 )
 
 // Bar defines model for Bar.
@@ -49,7 +51,7 @@ func (s Bar) Validate() error {
 	if err := validation.Validate(
 		s,
 		validation.In(
-			BarBar, BarFoo, BarFoo1, BarFoo2, BarFoo3, BarFoo4, BarFooBar, BarFooBar1,
+			BarBar, BarFoo, BarFoo1, BarFoo2, BarFoo3, BarFooBar, BarFooBar1, BarN1, BarN1Foo,
 		),
 		validation.Skip, // do not recurse infinitely
 	); err != nil {
@@ -430,11 +432,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/0yQzU4DMQyEX6UaOIbsUm45cijiGRCqoq23DeraUWKQqirvjpyFQi4z+ZnYn6+YZMnC",
-	"xFoRrqjTiZbY7XMsJsSfC8IbdiJw/dCZ39zcw+oe/z/YrBuTDRz2O5E93h30kgkBVUviI1prDolnsTqa",
-	"9Gx33ns4fFGpSRgBox/9iOYgmTjmhIAnP/otHHLUU291mKX/cSQ1kUwlahJ+PSDghXTtplDNwpV6ZDuO",
-	"JpOwEvdUzPmcpp4bPqrV/h2HuaS09OB9oRkBd8Pf4IafqQ0G326UsZR4WSEPVKeSsq5Ihtj6+g4AAP//",
-	"Jkt64H8BAAA=",
+	"H4sIAAAAAAAC/0xQQU4DMQz8SjVwDNml3HLkUMQbEKqirbcN6tpRYpCqKn9HzkIhl5kkHtszV0yyZGFi",
+	"rQhX1OlES+z0ORYD4s8F4Q07Ebj+6IxvbuxhZY//CzbrxWADh/1OZG81eHfQSyYEVC2Jj2itOSSexWZp",
+	"0rP9ee/h8EWlJmEEjH70I5qDZOKYEwKe/Oi3cMhRT33dYZbe40hqIJlK1CT8ekDAC+m6UaGahSt1yXYc",
+	"DSZhJe6qmPM5TV03fFSb/RuJsaS0dOF9oRkBd8NfeMNPcoMF0G4uYynxspo8UJ1KyrpaMoutn+8AAAD/",
+	"/y6OlsyDAQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/issues/issue-illegal_enum_names/issue_test.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue_test.go
@@ -47,8 +47,9 @@ func TestIllegalEnumNames(t *testing.T) {
 	require.Equal(t, `"Foo"`, constDefs["BarFoo"])
 	require.Equal(t, `"Foo Bar"`, constDefs["BarFooBar"])
 	require.Equal(t, `"Foo-Bar"`, constDefs["BarFooBar1"])
-	require.Equal(t, `"1Foo"`, constDefs["BarFoo1"])
-	require.Equal(t, `" Foo"`, constDefs["BarFoo2"])
-	require.Equal(t, `" Foo "`, constDefs["BarFoo3"])
-	require.Equal(t, `"_Foo_"`, constDefs["BarFoo4"])
+	require.Equal(t, `"1Foo"`, constDefs["BarN1Foo"])
+	require.Equal(t, `" Foo"`, constDefs["BarFoo1"])
+	require.Equal(t, `" Foo "`, constDefs["BarFoo2"])
+	require.Equal(t, `"_Foo_"`, constDefs["BarFoo3"])
+	require.Equal(t, `"1"`, constDefs["BarN1"])
 }

--- a/internal/test/issues/issue-illegal_enum_names/spec.yaml
+++ b/internal/test/issues/issue-illegal_enum_names/spec.yaml
@@ -31,3 +31,4 @@ components:
         - ' Foo'
         - ' Foo '
         - _Foo_
+        - "1"

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -137,7 +137,7 @@ type EnsureEverythingIsReferencedResponseOK struct {
 	//
 	// This should be an interface{}
 	AnyType2         *AnyType2         `json:"anyType2,omitempty"`
-	CustomStringType *CustomStringType `json:"customStringType,omitempty"`
+	CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
 }
 
 // Validate perform validation on the EnsureEverythingIsReferencedResponseOK
@@ -772,7 +772,7 @@ type EnsureEverythingIsReferencedResponseJSON200 struct {
 	//
 	// This should be an interface{}
 	AnyType2         *AnyType2         `json:"anyType2,omitempty"`
-	CustomStringType *CustomStringType `json:"customStringType,omitempty"`
+	CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
 }
 type EnsureEverythingIsReferencedResponse struct {
 	Body         []byte
@@ -1558,25 +1558,25 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/7RWX2/bNhD/KgeuwF4cy3YarPFbVnRDBqwNmgB9iPNAi2eLjXRkyVMSwfB3H0jKll3L",
-	"WbN0eYlo8v78fvd3JXJTWUNI7MV0Jax0skJGF0/X7DQtL+lKchHOCn3utGVtSEzFBfh4D1ZyAVtJMRA6",
-	"XIdfxUCQrFBMhedw4fBbrR0qMWVX40D4vMBKBtXc2PaZpqVYr9eby+jI2TVLx/6L5uJjXc3RHXpzU2gP",
-	"SQSCTfBRBB41FyCBkthgY8jMv2LOYj0QF9TcNBbHYrrqTpMeuO0NOLQOfWAMJDUQFA4BAGY0o+RFYepS",
-	"wRxBEmhidAuZ42o9o2Dvfe3ZVInam+jMSiyMqySLqcjjZefmho+B+BMJnc4/Jb87xjogH+uylPMSr5yx",
-	"6FhjiujeyUQ0suyhfLC9vCC10RXe0fY7Be1Arovq6vjly5Tuab3tvvv13R2ENaQP5rXT3FyHnEjoZZ6j",
-	"9yds7pHCeY7SoftjQ/5fX25OUiQgvYT4cjgj0WZjMJGEuhAVzDYlrKaF6UlM9Ay59OhhYRw8SKdN7UF7",
-	"X8efalJgHtAB6wqHcFWi9AhSKZDAG9kgOqOQbvN6CQv9hCq5xZoDicnKNbqH6NoDOp+sj4ej4SgFF0la",
-	"LabidDgajsUgFmikJUPytcMTfEDXcKFpeaL9icMFOqQ8xXWJfKTmkJQ1mhjwSXv24A1wIRm6xgK5pFAN",
-	"uUPJqEATcKH9jLzFHCQpIMPhgXU1oYq4QtLKYOZSian4EB38sPXv0n/uvAs54a0hn4I8GY3Cv9wQI0Wn",
-	"pbWlzqO27Ks3MfRd59kvENl1A/HG4UJMxS9ZByVrm1K27RrrwUZm8oMykyCT93SB52QPukZIuO+TPv4N",
-	"RJZyKxtPfjsaur/lPUIgFWrytbXGhchE0p449jQPytCvDNYhVpahexVvhz1hugx2g9VXhuQ5Ivb7YIC7",
-	"q+upKl+jKoDPKunulXmkVytq5Gu8CWoULmRd8v9I3k9C/H3mvTs73jQai7AM8hEBPBZIsBk92aa9Q1eW",
-	"IB3CZl4cT7t3Z+10QM+/G9X8NNJ65mpCu5Pjwb1dAiaj8+zNyrNbH+XhfYH5vQe96FanBFVhXsqOgrLp",
-	"BzwZnYtDHwZ7K9xtP7LuSba34q3vdiCcjrLVQpYlF87Uy2J9iOAz+jBwFNxj82ic2t18rMM4pUKzDyMv",
-	"EBj3srZxtJT04Dod/QisnhVzx9kXrZq7oN+Os9U4mjoeuKuNJzt7ZliD46a53TN7kL1NU/ffcCT7z0J4",
-	"Ll0Pd+X1+u7ZZD0/nqOlRuKUoD72fdCUG+cw57IJ32WtUMXFpi29RMPcqCZM9hl1eI+W7vkRWr7V6Jqd",
-	"+Brzsrj+53bQ9t5dJj61DSoiE33Fv7NyRgj7y+btXfAn1ksLsXZluz1Os6zdzsK+N1SItpJ2KHUoyH8C",
-	"AAD//ypj9OOiDQAA",
+	"H4sIAAAAAAAC/7RW32/bNhD+Vw5cgb3Ylu22WOO3ruiGDFgbNAH6UOeBFs8WG+nIkqfEguH/fSApW3Yt",
+	"Z83S5SWiyfvxfd/xeBuRm8oaQmIvZhthpZMVMrq4umanaXVJV5KLsFboc6cta0NiJt6Cj/tgJRewtxQD",
+	"ocN2+FUMBMkKxUx4DhsOv9XaoRIzdjUOhM8LrGRwzY1tj2laie12u9uMiby+ZunYf9ZcfKirBbrTbG4K",
+	"7SGZQIgJPprAg+YCJFAyG+wCmcVXzFlsB+ItNTeNxYmYbbrVtAduuwMOrUMfGANJDQSHoznNKWVQmLpU",
+	"sECQBJoY3VLmuNnOKcR6V3s2VaL1JiayEUvjKsliJvK42aXYcjEQ66GRVg9zo3CFNMQ1OzlkufLJ3IiZ",
+	"WEgnAmd/IqHT+ceEruO1g/uhLku5KPHKGYuONSbdj1YmYpZljzCD/eZbUjtf4Rztv5O0J3ad9pvzm09z",
+	"euT1S/fd7+/2RPxQZJjXTnNzHSonoZd5jt4P2dwhhfUCpUP3x06mvz7fDJNmkE5CPDmak2hrNoRIRp2Y",
+	"BbNNZa1paXrKFz1DLj16WBoH99JpU3vQ3tfxp5oUmHt0wLrCEVyVKD2CVAok8M42mM4pFOWiXsFSr1Gl",
+	"tFhzIDFFuUZ3H1O7R+dT9MloPBoncZGk1WImXo7Go4kYxGscacmQfO1wiPfoGi40rYbaDx0u0SHlSdcV",
+	"8pmbiaSs0cSAa+3ZgzfAhWTo2g/kksK9yR1KRgWagAvt5+Qt5iBJARkOB6yrCVXEFYpWhjCXSszE+5jg",
+	"+31+l/5Tl12oCW8N+STydDwO/3JDjBSTltaWOo/esq/eROm7/nR8QWTXM8QLh0sxE79kHZSsbV3Zvrds",
+	"Bzub6Q/aTINN3tMvHrM96S+h4L4v+vg3EFmqrWwy/e2sdH/LO4RAKtTka2uNC8pE0tYcO58HZehXBusQ",
+	"K8vQnYq7ox6ZLkPcEPWZkjxGxHEfDHAPfa2r8jmuAvisku5OmQd6tqNGPieb4EbhUtYl/4/k/STE31fe",
+	"m9fnm0ZjEVbBPiKAhwIJdk9Ptmvv0F1LkA5h916cL7s3r9vXAT3/blTz00jreVcT2oMaD+kdEjAdX2Qv",
+	"Np7d9iwP7wrM7zzoZTdgJagK81J2FJRNP+Dp+EKc5jA4GvS+9CPrjmRHg+D29gDCy3G2Wcqy5MKZelVs",
+	"TxF8Qh8eHAV32DwYpw5nJOswvlKh2YcnLxAYp7e2cbSU9OB6Of4RWD2D6EGyTxpID0G/mmSbSQx1Xrir",
+	"XSYH02gYluM8up9Ge5C9Sq/uv+FI8R+F8Fi5nk7U2+3to8V6cb5GS43EqUB97PugKTfOYc5lE77LWqGK",
+	"g0179RINC6Oa8LLPqcN79upenKHlW42uOdDXmKfp+p/bQdt7D5n42DaoiEz0Xf6DkTNCOB42v9yGfOJ9",
+	"aSHWrmynx1mWtdNZmPdGCtFW0o6kDhfynwAAAP//LJE8EMgNAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/schemas/schemas.yaml
+++ b/internal/test/schemas/schemas.yaml
@@ -119,12 +119,14 @@ components:
     AnyType1: {}
     AnyType2:
       description: |
-        AnyType2 represents any type.    
-        
+        AnyType2 represents any type.
+
         This should be an interface{}
     CustomStringType:
       type: string
       format: custom
+      x-oapi-codegen-extra-tags:
+        foo: bar
     NullableProperties:
       type: object
       properties:
@@ -154,7 +156,7 @@ components:
         type: string
   securitySchemes:
     # This security scheme has a - in it, we need to make sure the name gets
-    # remapped to a valid Go id. See bug 
+    # remapped to a valid Go id. See bug
     access-token:
       type: http
       scheme: bearer

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers"
-	"github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
 )
 
 // Options to customize request validation, openapi3filter specified options will be passed through.
@@ -29,7 +29,7 @@ func OapiRequestValidator(swagger *openapi3.T) func(next http.Handler) http.Hand
 // OapiRequestValidatorWithOptions Creates middleware to validate request by swagger spec.
 // This middleware is good for net/http either since go-chi is 100% compatible with net/http.
 func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func(next http.Handler) http.Handler {
-	router, err := legacy.NewRouter(swagger)
+	router, err := gorillamux.NewRouter(swagger)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/pkg/testutil"
@@ -20,7 +21,7 @@ info:
   version: 1.0.0
   title: TestServer
 servers:
-  - url: http://deepmap.ai
+  - url: http://deepmap.ai/
 paths:
   /resource:
     get:
@@ -91,13 +92,23 @@ components:
       bearerFormat: JWT
 `
 
-func doGet(t *testing.T, mux *chi.Mux, url string) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, mux)
+func doGet(t *testing.T, mux *chi.Mux, rawURL string) *httptest.ResponseRecorder {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("Invalid url: %s", rawURL)
+	}
+
+	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJson().GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 
-func doPost(t *testing.T, mux *chi.Mux, url string, jsonBody interface{}) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Post(url).WithJsonBody(jsonBody).GoWithHTTPHandler(t, mux)
+func doPost(t *testing.T, mux *chi.Mux, rawURL string, jsonBody interface{}) *httptest.ResponseRecorder {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("Invalid url: %s", rawURL)
+	}
+
+	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJsonBody(jsonBody).GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -163,6 +163,7 @@ type GetTestByNameResponse struct {
 	assert.Contains(t, code, "Top *int `json:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
+	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
 
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)
@@ -304,6 +305,9 @@ components:
         dead_since:
           type: string
           format: date-time
+          x-oapi-codegen-extra-tags:
+            tag1: value1
+            tag2: value2
         cause:
           type: string
           enum: [car, dog, oldage]

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -10,6 +10,7 @@ import (
 const (
 	extPropGoType    = "x-go-type"
 	extPropOmitEmpty = "x-omitempty"
+	extPropExtraTags = "x-oapi-codegen-extra-tags"
 )
 
 func extTypeName(extPropValue interface{}) (string, error) {
@@ -26,7 +27,6 @@ func extTypeName(extPropValue interface{}) (string, error) {
 }
 
 func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
-
 	raw, ok := extPropValue.(json.RawMessage)
 	if !ok {
 		return false, fmt.Errorf("failed to convert type: %T", extPropValue)
@@ -38,4 +38,16 @@ func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
 	}
 
 	return omitEmpty, nil
+}
+
+func extExtraTags(extPropValue interface{}) (map[string]string, error) {
+	raw, ok := extPropValue.(json.RawMessage)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert type: %T", extPropValue)
+	}
+	var tags map[string]string
+	if err := json.Unmarshal(raw, &tags); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal json")
+	}
+	return tags, nil
 }

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -446,11 +446,28 @@ func GenFieldsFromProperties(props []Property) []string {
 			}
 		}
 
+		fieldTags := make(map[string]string)
+
 		if p.Required || p.Nullable || !omitEmpty {
-			field += fmt.Sprintf(" `json:\"%s\"`", p.JsonFieldName)
+			fieldTags["json"] = p.JsonFieldName
 		} else {
-			field += fmt.Sprintf(" `json:\"%s,omitempty\"`", p.JsonFieldName)
+			fieldTags["json"] = p.JsonFieldName + ",omitempty"
 		}
+		if extension, ok := p.ExtensionProps.Extensions[extPropExtraTags]; ok {
+			if tags, err := extExtraTags(extension); err == nil {
+				keys := SortedStringKeys(tags)
+				for _, k := range keys {
+					fieldTags[k] = tags[k]
+				}
+			}
+		}
+		// Convert the fieldTags map into Go field annotations.
+		keys := SortedStringKeys(fieldTags)
+		tags := make([]string, len(keys))
+		for i, k := range keys {
+			tags[i] = fmt.Sprintf(`%s:"%s"`, k, fieldTags[k])
+		}
+		field += "`" + strings.Join(tags, " ") + "`"
 		fields = append(fields, field)
 	}
 	return fields

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -496,7 +496,7 @@ func SanitizeEnumNames(enumNames []string) map[string]string {
 	sanitizedDeDup := make(map[string]string, len(deDup))
 
 	for _, n := range deDup {
-		sanitized := SchemaNameToTypeName(SanitizeGoIdentity(n))
+		sanitized := SanitizeGoIdentity(SchemaNameToTypeName(n))
 
 		if _, dup := dupCheck[sanitized]; !dup {
 			sanitizedDeDup[sanitized] = n

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -24,7 +24,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers"
-	"github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 )
@@ -67,7 +67,7 @@ type Options struct {
 
 // Create a validator from a swagger object, with validation options
 func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) echo.MiddlewareFunc {
-	router, err := legacy.NewRouter(swagger)
+	router, err := gorillamux.NewRouter(swagger)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/pkg/testutil"
@@ -35,7 +36,7 @@ info:
   version: 1.0.0
   title: TestServer
 servers:
-  - url: http://deepmap.ai
+  - url: http://deepmap.ai/
 paths:
   /resource:
     get:
@@ -106,13 +107,23 @@ components:
       bearerFormat: JWT
 `
 
-func doGet(t *testing.T, e *echo.Echo, url string) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Get(url).WithAcceptJson().Go(t, e)
+func doGet(t *testing.T, e *echo.Echo, rawURL string) *httptest.ResponseRecorder {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("Invalid url: %s", rawURL)
+	}
+
+	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJson().GoWithHTTPHandler(t, e)
 	return response.Recorder
 }
 
-func doPost(t *testing.T, e *echo.Echo, url string, jsonBody interface{}) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Post(url).WithJsonBody(jsonBody).Go(t, e)
+func doPost(t *testing.T, e *echo.Echo, rawURL string, jsonBody interface{}) *httptest.ResponseRecorder {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("Invalid url: %s", rawURL)
+	}
+
+	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJsonBody(jsonBody).GoWithHTTPHandler(t, e)
 	return response.Recorder
 }
 

--- a/pkg/testutil/request_helpers.go
+++ b/pkg/testutil/request_helpers.go
@@ -85,6 +85,10 @@ func (r *RequestBuilder) WithHeader(header, value string) *RequestBuilder {
 	return r
 }
 
+func (r *RequestBuilder) WithHost(value string) *RequestBuilder {
+	return r.WithHeader("Host", value)
+}
+
 func (r *RequestBuilder) WithContentType(value string) *RequestBuilder {
 	return r.WithHeader("Content-Type", value)
 }
@@ -145,6 +149,9 @@ func (r *RequestBuilder) GoWithHTTPHandler(t *testing.T, handler http.Handler) *
 	req := httptest.NewRequest(r.Method, r.Path, bodyReader)
 	for h, v := range r.Headers {
 		req.Header.Add(h, v)
+	}
+	if host, ok := r.Headers["Host"]; ok {
+		req.Host = host
 	}
 	for _, c := range r.Cookies {
 		req.AddCookie(c)


### PR DESCRIPTION
From commits from upstream:
- Stop depend on the github.com/getkin/kin-openapi/routers/legacy (#383)
- Fix escaped url parsing (#381)
- Fix constant names for integers in strings (#379)
- Added extension for adding extra tags (#356)
- Refactor extra tags
- Update docs for x-oapi-codegen-extra-tags
- Revert "Fix escaped url parsing (#381)"
